### PR TITLE
Allow versions to be specified as an Array.

### DIFF
--- a/data/ore/templates/gemspec/[name].gemspec.erb
+++ b/data/ore/templates/gemspec/[name].gemspec.erb
@@ -29,12 +29,12 @@ Gem::Specification.new do |gem|
 <%- unless @dependencies.empty? -%>
 
 <%-   @dependencies.sort.each do |name,version| -%>
-  gem.add_dependency '<%= name %>', '<%= version %>'
+  gem.add_dependency '<%= name %>', <%= version.inspect %>
 <%-   end -%>
 <%- end -%>
 
 <%- unless @development_dependencies.empty? -%>
 <%-   @development_dependencies.sort.each do |name,version| -%>
-  gem.add_development_dependency '<%= name%>', '<%= version %>'
+  gem.add_development_dependency '<%= name%>', <%= version.inspect %>
 <%-   end -%>
 <%- end -%>end


### PR DESCRIPTION
So admittedly, this was a quick-and-dirty hack to get this working, but wanted to raise this issue since it has significant implications for anyone who is trying to follow semver. You need to be able to specify gem dependencies in the form `'~> x.y', '>= x.y.z'` if you want your gem dependency declarations to work for semver projects without breaking horribly anytime someone increments a minor version number.

Obviously, this fix is going to do weird stuff if anyone provides anything but a `String` or an `Array` value when they declare their dependencies and I'm not checking for that, however the cause of the problem ought to be obvious in that scenario.